### PR TITLE
infra: add cursor casks and local bin path

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,5 +1,4 @@
 PATH="$PATH":~/bin
-export PATH="$HOME/.local/bin:$PATH"
 export LANG=ja_JP.UTF-8
 export HISTCONTROL=$HISTCONTROL${HISTCONTROL+,}ignoredups
 export HISTCONTROL=ignoreboth

--- a/.bashrc
+++ b/.bashrc
@@ -1,4 +1,5 @@
 PATH="$PATH":~/bin
+export PATH="$HOME/.local/bin:$PATH"
 export LANG=ja_JP.UTF-8
 export HISTCONTROL=$HISTCONTROL${HISTCONTROL+,}ignoredups
 export HISTCONTROL=ignoreboth

--- a/etc/init/assets/brew/Brewfile
+++ b/etc/init/assets/brew/Brewfile
@@ -75,7 +75,6 @@ cask 'slack'
 cask 'the-unarchiver'
 cask 'hammerspoon'
 cask 'font-hack-nerd-font'
-cask 'cursor'
 cask 'cursor-cli'
 
 #mas 'Be Focused Pro', id: 961632517

--- a/etc/init/assets/brew/Brewfile
+++ b/etc/init/assets/brew/Brewfile
@@ -75,6 +75,8 @@ cask 'slack'
 cask 'the-unarchiver'
 cask 'hammerspoon'
 cask 'font-hack-nerd-font'
+cask 'cursor'
+cask 'cursor-cli'
 
 #mas 'Be Focused Pro', id: 961632517
 #mas 'iMovie', id: 408981434

--- a/etc/init/osx/bundle.sh
+++ b/etc/init/osx/bundle.sh
@@ -25,6 +25,11 @@ if has "brew"; then
     fi
 
     brew bundle
+
+    # cursor-cli quarantine属性削除
+    if [ -d "/opt/homebrew/Caskroom/cursor-cli" ]; then
+        xattr -dr com.apple.quarantine /opt/homebrew/Caskroom/cursor-cli/
+    fi
 else
     die "you should install brew"
 fi

--- a/etc/init/osx/bundle.sh
+++ b/etc/init/osx/bundle.sh
@@ -27,8 +27,9 @@ if has "brew"; then
     brew bundle
 
     # cursor-cli quarantine属性削除
-    if [ -d "/opt/homebrew/Caskroom/cursor-cli" ]; then
-        xattr -dr com.apple.quarantine /opt/homebrew/Caskroom/cursor-cli/
+    cursor_cask_path="$(brew --prefix)/Caskroom/cursor-cli"
+    if [ -d "$cursor_cask_path" ]; then
+        xattr -dr com.apple.quarantine "$cursor_cask_path"/
     fi
 else
     die "you should install brew"


### PR DESCRIPTION
## Summary
- `etc/init/assets/brew/Brewfile` に `cursor` と `cursor-cli` のcaskを追加
- `.bashrc` に `$HOME/.local/bin` をPATH追加

## Test plan
未実施（設定変更のみ）

## タスク
- [x] `cursor-agent --version` を手動確認