### PR TITLE
feat: add Cursor rules and AGENTS.md for AI-driven development

### DIFF
--- a/.cursor/rules/dotfiles.mdc
+++ b/.cursor/rules/dotfiles.mdc
@@ -1,0 +1,48 @@
+---
+description: dotfilesリポジトリ全体のルール
+globs: ["**/*"]
+alwaysApply: true
+---
+
+# dotfilesリポジトリルール
+
+## リポジトリ概要
+
+macOS専用の個人dotfiles管理リポジトリ。Homebrew前提。
+
+## 構造規約
+
+### シンボリックリンク管理
+
+- ルートディレクトリの`.`で始まるファイル/ディレクトリはホームディレクトリにリンクされる
+- `bin/`配下のスクリプトは`~/bin/`にリンクされPATHに追加される
+- `.config/`配下は`~/.config/`にリンクされる
+
+### 除外ファイル
+
+以下はデプロイ対象外（Makefileの`DOTFILES_EXCLUDES`で定義）:
+- `.idea`, `.DS_Store`, `.git`, `.gitmodules`, `.gitignore`, `.config`
+
+## AI IDE検出パターン
+
+`.bashrc`の`is_ai_ide()`関数は以下を検出:
+- Windsurf: `VSCODE_PID` + `CODEIUM_EDITOR_APP_ROOT`
+- VSCode/Cursor: `TERM_PROGRAM=vscode`
+- Cursor: `CURSOR_PID`
+- Claude Code: `CLAUDE_CODE`
+
+**この検出パターンを変更する場合は既存のパターンを維持すること。**
+
+## ドキュメント更新
+
+以下の場合はREADME.mdを更新:
+- 新しい外部依存を追加した場合
+- 新しいセットアップ手順が必要な場合
+- 重要な設定変更を行った場合
+
+## Makefileコマンド
+
+新しいターゲットを追加する場合:
+1. `.PHONY`に追加
+2. `help`ターゲットに説明を追加
+3. 小文字・ハイフン区切りの命名規則に従う

--- a/.cursor/rules/dotfiles.mdc
+++ b/.cursor/rules/dotfiles.mdc
@@ -16,12 +16,14 @@ macOS専用の個人dotfiles管理リポジトリ。Homebrew前提。
 
 - ルートディレクトリの`.`で始まるファイル/ディレクトリはホームディレクトリにリンクされる
 - `bin/`配下のスクリプトは`~/bin/`にリンクされPATHに追加される
-- `.config/`配下は`~/.config/`にリンクされる
+- `.config/`は特別処理: ディレクトリ自体はリンクせず、内部のファイルを個別に`~/.config/`へリンク
 
 ### 除外ファイル
 
 以下はデプロイ対象外（Makefileの`DOTFILES_EXCLUDES`で定義）:
-- `.idea`, `.DS_Store`, `.git`, `.gitmodules`, `.gitignore`, `.config`
+- `.idea`, `.DS_Store`, `.git`, `.gitmodules`, `.gitignore`
+
+**注**: `.config`は除外リストに含まれるが、内部ファイルは`CONFIG_FILES`として別途処理される。
 
 ## AI IDE検出パターン
 

--- a/.cursor/rules/lua.mdc
+++ b/.cursor/rules/lua.mdc
@@ -1,0 +1,100 @@
+---
+description: Lua設定ファイルのコーディング規約（WezTerm, Hammerspoon）
+globs: [".wezterm.lua", ".hammerspoon/**/*.lua"]
+---
+
+# Lua設定ファイル規約
+
+WezTermおよびHammerspoon設定用のLuaコーディング規約。
+
+## 基本ルール
+
+### local変数の使用
+
+グローバル変数を避け、常に`local`を使用:
+
+```lua
+-- Good
+local wezterm = require("wezterm")
+local config = {}
+
+-- Bad
+wezterm = require("wezterm")
+config = {}
+```
+
+### モジュールのrequire
+
+明示的にrequireし、ローカル変数に代入:
+
+```lua
+local wezterm = require("wezterm")
+local act = wezterm.action
+```
+
+## WezTerm設定
+
+### 設定構造
+
+```lua
+local wezterm = require("wezterm")
+local config = {}
+
+-- 設定をconfigテーブルに追加
+config.font = wezterm.font("JetBrains Mono")
+config.font_size = 14.0
+
+return config
+```
+
+### キーバインディング
+
+```lua
+config.keys = {
+  {
+    key = "c",
+    mods = "CMD",
+    action = act.CopyTo("Clipboard"),
+  },
+}
+```
+
+## Hammerspoon設定
+
+### モジュール分割
+
+機能ごとにファイルを分割し、`init.lua`でrequire:
+
+```lua
+-- init.lua
+require("altDoublePress")
+require("ctrlDoublePress")
+```
+
+### 各モジュールの構造
+
+```lua
+-- example.lua
+local module = {}
+
+local function privateFunction()
+  -- ...
+end
+
+function module.publicFunction()
+  -- ...
+end
+
+return module
+```
+
+## コメント
+
+- 設定の目的を説明するコメントを追加
+- 複雑なロジックには詳細なコメントを付ける
+
+```lua
+-- ダブルタップでアプリケーション切り替え
+-- 300ms以内の2回押しを検出
+local DOUBLE_TAP_DELAY = 0.3
+```

--- a/.cursor/rules/makefile.mdc
+++ b/.cursor/rules/makefile.mdc
@@ -1,0 +1,97 @@
+---
+description: Makefileのコーディング規約
+globs: ["Makefile", "*.mk"]
+---
+
+# Makefile規約
+
+## 基本ルール
+
+### ターゲット命名
+
+- 小文字を使用
+- 複数単語はハイフン区切り
+- 動詞から始める（deploy, install, clean等）
+
+```makefile
+# Good
+deploy:
+clean-all:
+run-tests:
+
+# Bad
+Deploy:
+clean_all:
+runTests:
+```
+
+### .PHONY宣言
+
+実ファイルを生成しないターゲットは`.PHONY`に追加:
+
+```makefile
+.PHONY: help list init deploy update install clean lint validate
+```
+
+### helpターゲット
+
+新しいターゲット追加時は`help`にも追加:
+
+```makefile
+help:
+	@echo "make deploy         #=> Create symlink to home directory"
+	@echo "make lint           #=> Run shellcheck on scripts"
+```
+
+## 変数定義
+
+### 命名規則
+
+- 大文字とアンダースコア
+- 意味のある名前
+
+```makefile
+DOTFILES_TARGET   := $(wildcard .??*) bin
+DOTFILES_EXCLUDES := .idea .DS_Store .git
+```
+
+### 代入演算子
+
+- `:=`: 即時評価（推奨）
+- `=`: 遅延評価
+- `?=`: 未定義時のみ代入
+
+## コマンド
+
+### サイレント実行
+
+ユーザーに見せる必要のない内部コマンドは`@`でサイレント化:
+
+```makefile
+deploy:
+	@echo "==> Start to deploy dotfiles"
+	@$(foreach val, $(FILES), ln -sfnv $(val) $(HOME)/$(val);)
+```
+
+### エラーハンドリング
+
+失敗しても続行する場合は`-`を使用（cleanターゲット等）:
+
+```makefile
+clean:
+	@-$(foreach val, $(FILES), rm -vrf $(HOME)/$(val);)
+```
+
+## このリポジトリの既存ターゲット
+
+| ターゲット | 説明 |
+|------------|------|
+| `help` | コマンド一覧表示 |
+| `list` | デプロイ対象ファイル一覧 |
+| `deploy` | シンボリックリンク作成 |
+| `init` | 環境初期化 |
+| `install` | update + deploy + init |
+| `update` | git pull |
+| `clean` | dotfiles削除 |
+| `lint` | shellcheck実行 |
+| `validate` | シンボリックリンク検証 |

--- a/.cursor/rules/shell.mdc
+++ b/.cursor/rules/shell.mdc
@@ -1,0 +1,114 @@
+---
+description: シェルスクリプトのコーディング規約（Google Shell Style Guide + shellcheck準拠）
+globs: [".bashrc", ".bash_profile", "bin/*", "etc/**/*.sh", "scripts/**/*.sh"]
+---
+
+# シェルスクリプト規約
+
+Google Shell Style Guide + shellcheck strict準拠。macOS + Homebrew bash前提。
+
+## 基本ルール
+
+### shebang
+
+```bash
+#!/usr/bin/env bash
+```
+
+### エラーハンドリング（スクリプトファイル）
+
+スクリプトファイルの先頭に必ず追加:
+
+```bash
+set -euo pipefail
+```
+
+- `-e`: コマンド失敗時に即座に終了
+- `-u`: 未定義変数の参照でエラー
+- `-o pipefail`: パイプライン内のエラーを検出
+
+**注意**: `.bashrc`や`.bash_profile`のような対話シェル設定では`set -e`は使用しない。
+
+### 変数展開
+
+常にダブルクォートで囲む:
+
+```bash
+# Good
+echo "$variable"
+command "$1" "$2"
+
+# Bad
+echo $variable
+command $1 $2
+```
+
+### 条件分岐
+
+`[[ ]]`を使用（bash拡張、より安全）:
+
+```bash
+# Good
+if [[ -n "$var" ]]; then
+if [[ "$var" == "value" ]]; then
+
+# Bad
+if [ -n "$var" ]; then
+if [ "$var" = "value" ]; then
+```
+
+### 関数定義
+
+```bash
+# Good
+function_name() {
+  local var="value"
+  # ...
+}
+
+# Bad（functionキーワードは非推奨）
+function function_name {
+  # ...
+}
+```
+
+### ローカル変数
+
+関数内では`local`を使用:
+
+```bash
+my_function() {
+  local result
+  result=$(some_command)
+  echo "$result"
+}
+```
+
+## エラー出力
+
+エラーメッセージは標準エラー出力へ:
+
+```bash
+echo "Error: something went wrong" >&2
+exit 1
+```
+
+## Usage表示
+
+スクリプトには引数チェックとUsage表示を含める:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $(basename "$0") <argument>" >&2
+  exit 2
+fi
+```
+
+## shellcheck
+
+- `make lint`で検証可能
+- `.shellcheckrc`で設定をカスタマイズ
+- SC1090, SC1091（外部ソース）は除外済み

--- a/.cursor/rules/shell.mdc
+++ b/.cursor/rules/shell.mdc
@@ -66,7 +66,7 @@ function_name() {
   # ...
 }
 
-# Bad（functionキーワードは非推奨）
+# Bad (functionキーワードは非推奨)
 function function_name {
   # ...
 }

--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,5 @@
+{
+  "setup-worktree": [
+    "npm install"
+  ]
+}

--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,5 +1,5 @@
 {
   "setup-worktree": [
-    "npm install"
+    "make deploy"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,111 @@
+# AGENTS.md - AIエージェント向けリポジトリガイド
+
+このドキュメントはAIエージェント（Cursor, Claude, Windsurf等）がこのリポジトリを理解・操作するためのガイドです。
+
+## リポジトリ概要
+
+macOS向けの個人用dotfiles管理リポジトリ。シンボリックリンクでホームディレクトリに配置する構成。
+
+## ディレクトリ構造
+
+```
+dotfiles/
+├── AGENTS.md              # このファイル（AIエージェント向けガイド）
+├── README.md              # 人間向けセットアップガイド
+├── Makefile               # デプロイ・管理コマンド
+├── .bashrc                # メインのシェル設定
+├── .bash_profile          # ログインシェル設定
+├── .gitconfig             # Git設定
+├── .vimrc                 # Vim設定
+├── .tmux.conf             # tmux設定
+├── .wezterm.lua           # WezTermターミナル設定
+├── .config/               # XDG設定ディレクトリ
+│   └── starship/          # starshipプロンプト設定
+├── .hammerspoon/          # macOS自動化（Lua）
+├── .vim/                  # Vimプラグイン設定（dein）
+├── bin/                   # カスタムスクリプト（PATHに追加される）
+├── etc/
+│   ├── install            # インストールスクリプト
+│   ├── init/              # 初期化スクリプト
+│   │   ├── init.sh        # メイン初期化
+│   │   ├── osx/           # macOS固有の初期化
+│   │   └── assets/        # Brewfile、カラースキーム等
+│   └── lib/               # 共通ライブラリ
+└── scripts/               # ユーティリティスクリプト
+```
+
+## 重要な設計パターン
+
+### シンボリックリンク構造
+
+このリポジトリのファイルはホームディレクトリにシンボリックリンクとして配置されます。
+
+```bash
+# 例: ~/.bashrc -> /path/to/dotfiles/.bashrc
+```
+
+**注意**: ファイルを追加・削除する場合は`Makefile`の`DOTFILES_EXCLUDES`と`DOTFILES_TARGET`を確認してください。
+
+### AI IDE検出パターン
+
+`.bashrc`には`is_ai_ide()`関数があり、AIツールの統合ターミナルを検出します。
+
+```bash
+is_ai_ide() {
+    [[ -n "$VSCODE_PID" && -n "$CODEIUM_EDITOR_APP_ROOT" ]] && return 0  # Windsurf
+    [[ "$TERM_PROGRAM" == "vscode" ]] && return 0  # VSCode/Cursor
+    [[ -n "$CURSOR_PID" ]] && return 0  # Cursor
+    [[ -n "$CLAUDE_CODE" ]] && return 0  # Claude Code
+    return 1
+}
+```
+
+AI IDE検出時にスキップされる設定:
+- tmux自動起動
+- starship初期化
+- bash-completion読み込み
+- hub/zoxide初期化
+
+**この関数を変更する場合は、既存の検出パターンを維持してください。**
+
+## Makefileコマンド
+
+| コマンド | 説明 |
+|----------|------|
+| `make list` | デプロイ対象ファイル一覧表示 |
+| `make deploy` | ホームディレクトリへシンボリックリンク作成 |
+| `make init` | 環境設定の初期化 |
+| `make install` | update + deploy + init を実行 |
+| `make update` | リポジトリの更新（git pull） |
+| `make clean` | dotfilesの削除 |
+| `make lint` | shellcheckでスクリプトを検証 |
+| `make validate` | シンボリックリンク整合性チェック |
+
+## ファイル別ガイドライン
+
+### シェルスクリプト（`.bashrc`, `bin/*`, `etc/**/*.sh`）
+
+- **shebang**: `#!/usr/bin/env bash`（Homebrew bash前提）
+- **エラーハンドリング**: `set -euo pipefail` を使用
+- **変数展開**: 常にダブルクォート `"$var"`
+- **条件分岐**: `[[ ]]` を使用（bash拡張）
+- **リント**: `shellcheck` で検証
+
+### Lua設定（`.wezterm.lua`, `.hammerspoon/*.lua`）
+
+- **変数**: `local` を使用
+- **モジュール**: 明示的な `require`
+
+### 設定ファイル全般
+
+- 新しい設定を追加する前に、既存のパターンを確認
+- コメントで設定の目的を説明
+- 外部依存がある場合は`README.md`または`etc/init/assets/brew/Brewfile`に記載
+
+## 変更時のチェックリスト
+
+- [ ] 既存のコードスタイルに従っているか
+- [ ] shellcheckでエラーがないか（`make lint`）
+- [ ] シンボリックリンク構造を壊していないか
+- [ ] AI IDE検出パターンを維持しているか（該当する場合）
+- [ ] README.mdの更新が必要か（新しい依存や設定追加時）


### PR DESCRIPTION
## Summary

- Cursorルール（`.cursor/rules/`）を追加し、AIエージェントがコード規約を理解できるようにした
- `AGENTS.md`を追加し、AIエージェント向けのリポジトリガイドを提供

## 追加ファイル

- `.cursor/rules/dotfiles.mdc`: リポジトリ構造・命名規約
- `.cursor/rules/shell.mdc`: シェルスクリプト規約（Google Style Guide + shellcheck）
- `.cursor/rules/lua.mdc`: Lua設定規約（WezTerm, Hammerspoon）
- `.cursor/rules/makefile.mdc`: Makefile規約
- `AGENTS.md`: AIエージェント向けリポジトリガイド

## Test plan

- [ ] Cursorでルールが適用されることを確認
- [ ] AIエージェントがAGENTS.mdを参照してリポジトリを理解できることを確認