### PR TITLE
feat: add Makefile lint/validate commands and shellcheck compliance

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -269,13 +269,14 @@ fi
 function tmux_ssh() {
   if [[ -n $(printenv TMUX) ]]
   then
-    local window_name=$(tmux display -p '#{window_name}')
+    local window_name
+    window_name=$(tmux display -p '#{window_name}')
     # tmux rename-window -- "$@[-1]" # zsh specified
     tmux rename-window -- "${!#}" # for bash
-    command ssh $@
-    tmux rename-window $window_name
+    command ssh "$@"
+    tmux rename-window "$window_name"
   else
-    command ssh $@
+    command ssh "$@"
   fi
 }
 alias ssh=tmux_ssh

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,7 @@
+# shellcheck設定（macOS + Homebrew bash前提）
+shell=bash
+
+# 外部ソースファイルの警告を抑制
+# SC1090: Can't follow non-constant source
+# SC1091: Not following (file not found)
+disable=SC1090,SC1091

--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,10 @@ clean:
 lint:
 	@echo "==> Running shellcheck..."
 	@status=0; \
-	shellcheck -x bin/* 2>/dev/null || status=$$?; \
-	shellcheck -x etc/init/*.sh etc/init/osx/*.sh etc/lib/*.sh 2>/dev/null || status=$$?; \
-	shellcheck -x scripts/*.sh 2>/dev/null || status=$$?; \
-	shellcheck -x .bashrc .bash_profile 2>/dev/null || status=$$?; \
+	shellcheck -x bin/* || status=$$?; \
+	shellcheck -x etc/init/*.sh etc/init/osx/*.sh etc/lib/*.sh || status=$$?; \
+	shellcheck -x scripts/*.sh || status=$$?; \
+	shellcheck -x .bashrc .bash_profile || status=$$?; \
 	if [ $$status -ne 0 ]; then \
 		echo "==> shellcheck found issues (exit code: $$status)"; \
 	else \
@@ -74,7 +74,7 @@ lint:
 validate:
 	@echo "==> Checking symlink integrity..."
 	@$(foreach val, $(DOTFILES_FILES), \
-		if [[ -L "$(HOME)/$(val)" ]]; then \
+		if [ -L "$(HOME)/$(val)" ]; then \
 			if readlink "$(HOME)/$(val)" | grep -q "$(PWD)"; then \
 				echo "OK: $(val)"; \
 			else \

--- a/Makefile
+++ b/Makefile
@@ -60,16 +60,21 @@ clean:
 
 lint:
 	@echo "==> Running shellcheck..."
-	@shellcheck -x bin/* 2>/dev/null || true
-	@shellcheck -x etc/init/*.sh etc/init/osx/*.sh etc/lib/*.sh 2>/dev/null || true
-	@shellcheck -x scripts/*.sh 2>/dev/null || true
-	@shellcheck -x .bashrc .bash_profile 2>/dev/null || true
-	@echo "==> Done."
+	@status=0; \
+	shellcheck -x bin/* 2>/dev/null || status=$$?; \
+	shellcheck -x etc/init/*.sh etc/init/osx/*.sh etc/lib/*.sh 2>/dev/null || status=$$?; \
+	shellcheck -x scripts/*.sh 2>/dev/null || status=$$?; \
+	shellcheck -x .bashrc .bash_profile 2>/dev/null || status=$$?; \
+	if [ $$status -ne 0 ]; then \
+		echo "==> shellcheck found issues (exit code: $$status)"; \
+	else \
+		echo "==> Done. No issues found."; \
+	fi
 
 validate:
 	@echo "==> Checking symlink integrity..."
 	@$(foreach val, $(DOTFILES_FILES), \
-		if [ -L "$(HOME)/$(val)" ]; then \
+		if [[ -L "$(HOME)/$(val)" ]]; then \
 			if readlink "$(HOME)/$(val)" | grep -q "$(PWD)"; then \
 				echo "OK: $(val)"; \
 			else \

--- a/bin/battery
+++ b/bin/battery
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # @(#) battery ver.0.2 2014.12.17
 #
@@ -11,7 +11,7 @@
 #
 ######################################################################
 
-ostype() { echo $OSTYPE | tr '[A-Z]' '[a-z]'; }
+ostype() { echo "$OSTYPE" | tr '[:upper:]' '[:lower:]'; }
 determine_os()
 {
     case "$(ostype)" in
@@ -25,7 +25,7 @@ determine_os()
 shell_is_linux() { [[ $SHELL_PLATFORM == 'linux' || $SHELL_PLATFORM == 'bsd' ]]; }
 shell_is_osx()   { [[ $SHELL_PLATFORM == 'osx' ]]; }
 shell_is_bsd()   { [[ $SHELL_PLATFORM == 'bsd' || $SHELL_PLATFORM == 'osx' ]]; }
-has()       { type $1 >/dev/null 2>&1; return $?; }
+has()       { type "$1" >/dev/null 2>&1; return $?; }
 
 declare battery_danger=20
 declare get_battery_help=$(
@@ -41,7 +41,7 @@ usage: ${0##*/} [-h][-pt][-c {type}]
 END
 )
 
-function get_battery()
+get_battery()
 {
     get_battery_initialize
     [ -z "$percentage" ] && return 1
@@ -84,7 +84,7 @@ function get_battery()
     fi
 }
 
-function get_battery_initialize()
+get_battery_initialize()
 {
     determine_os
 
@@ -152,7 +152,7 @@ function get_battery_initialize()
     fi
 }
 
-function get_battery_color()
+get_battery_color()
 {
     if shell_is_osx; then
         if has 'pmset'; then
@@ -191,7 +191,7 @@ function get_battery_color()
     fi
 }
 
-function get_battery_color_tmux()
+get_battery_color_tmux()
 {
     for i in "$@"; do [[ $i =~ t ]] && t_opt=1; done
     if shell_is_osx; then

--- a/bin/get_ssid
+++ b/bin/get_ssid
@@ -1,19 +1,19 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-is_mac() { [[ $(echo $OSTYPE | tr '[A-Z]' '[a-z]') =~ 'darwin' ]]; }
+is_mac() { [[ "$(echo "$OSTYPE" | tr '[:upper:]' '[:lower:]')" =~ darwin ]]; }
 
-function get_ssid()
-{
-    local wifi_device=
-    local ip=
+get_ssid() {
+    local wifi_device
+    local ip
     if is_mac; then
         wifi_device=$(networksetup -listnetworkserviceorder | sed -En 's/^\(Hardware Port: (Wi-Fi|AirPort), Device: (en[0-9]+)\)$/\2/p')
-        if [ -z "$wifi_device" ]; then
+        if [[ -z "$wifi_device" ]]; then
             wifi_device=$(networksetup -listallhardwareports 2>/dev/null | awk '/Wi-Fi/{getline; print $2}')
         fi
-        if [ -n "$wifi_device" ]; then
+        if [[ -n "$wifi_device" ]]; then
             ip=$(ifconfig "$wifi_device" 2>/dev/null | awk '$1=="inet"{print $2; exit}')
-            if [ -n "$ip" ]; then
+            if [[ -n "$ip" ]]; then
                 echo "#[fg=green]$ip#[default]"
                 return 0
             fi

--- a/bin/git-wip
+++ b/bin/git-wip
@@ -1,9 +1,12 @@
-#! /bin/sh
-if [ $# -ne 2 ]; then
-  echo "Usage: git wip (branch-name) (commit-message)"
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: git wip <branch-name> <commit-message>" >&2
   exit 2
 fi
+
 git pull origin develop
-git checkout -b $1
+git checkout -b "$1"
 git commit --allow-empty -m "[wip] $2"
-#git push origin $1
+#git push origin "$1"

--- a/bin/imgcat
+++ b/bin/imgcat
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # tmux requires unrecognized OSC sequences to be wrapped with DCS tmux;
 # <sequence> ST, and for all ESCs in <sequence> to be replaced with ESC ESC. It
 # only accepts ESC backslash for ST.
-function print_osc() {
+print_osc() {
     if [[ $TERM == screen* ]] ; then
         printf "\033Ptmux;\033\033]"
     else
@@ -12,7 +12,7 @@ function print_osc() {
 }
 
 # More of the tmux workaround described above.
-function print_st() {
+print_st() {
     if [[ $TERM == screen* ]] ; then
         printf "\a\033\\"
     else
@@ -26,7 +26,7 @@ function print_st() {
 #   base64contents: Base64-encoded contents
 #   print_filename: If non-empty, print the filename 
 #                   before outputting the image
-function print_image() {
+print_image() {
     print_osc
     printf '1337;File='
     if [[ -n "$1" ]]; then
@@ -53,11 +53,11 @@ function print_image() {
     fi
 }
 
-function error() {
+error() {
     echo "ERROR: $*" 1>&2
 }
 
-function show_help() {
+show_help() {
     echo "Usage: imgcat [-p] filename ..." 1>& 2
     echo "   or: cat filename | imgcat" 1>& 2
 }
@@ -71,7 +71,7 @@ else
 fi
 
 # Show help if no arguments and no stdin.
-if [ $has_stdin = f -a $# -eq 0 ]; then
+if [[ "$has_stdin" == "f" ]] && [[ $# -eq 0 ]]; then
     show_help
     exit
 fi
@@ -105,7 +105,7 @@ while [ $# -gt 0 ]; do
 done
 
 # Read and print stdin
-if [ $has_stdin = t ]; then
+if [[ "$has_stdin" == "t" ]]; then
     print_image "" 1 "$(cat | base64)" ""
 fi
 

--- a/bin/imgls
+++ b/bin/imgls
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # tmux requires unrecognized OSC sequences to be wrapped with DCS tmux;
 # <sequence> ST, and for all ESCs in <sequence> to be replaced with ESC ESC. It
 # only accepts ESC backslash for ST.
-function print_osc() {
-    if [ x"$TERM" = "xscreen" ] ; then
+print_osc() {
+    if [[ "$TERM" == "screen" ]]; then
         printf "\033Ptmux;\033\033]"
     else
         printf "\033]"
@@ -11,19 +11,21 @@ function print_osc() {
 }
 
 # More of the tmux workaround described above.
-function print_st() {
-    if [ x"$TERM" = "xscreen" ] ; then
+print_st() {
+    if [[ "$TERM" == "screen" ]]; then
         printf "\a\033\\"
     else
         printf "\a"
     fi
 }
 
-function list_file() {
-  fn=$1
+list_file() {
+  local fn=$1
+  local dims
+  local rc
   dims=$(php -r 'if (!is_file($argv[1])) exit(1); $a = getimagesize($argv[1]); if ($a==FALSE) exit(1); else { echo $a[0] . "x" .$a[1]; exit(0); }' "$fn")
   rc=$?
-  if [[ $rc == 0 ]] ; then
+  if [[ $rc -eq 0 ]]; then
     print_osc
     printf '1337;File=name='`echo -n "$fn" | base64`";"
     wc -c "$fn" | awk '{printf "size=%d",$1}'
@@ -31,7 +33,7 @@ function list_file() {
     printf ":"
     base64 < "$fn"
     print_st
-    if [ x"$TERM" == "xscreen" ] ; then
+    if [[ "$TERM" == "screen" ]]; then
       # This works in plain-old tmux but does the wrong thing in iTerm2's tmux
       # integration mode. tmux doesn't know that the cursor moves when the
       # image code is sent, while iTerm2 does. I had to pick one, since

--- a/bin/ogr
+++ b/bin/ogr
@@ -1,19 +1,29 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Get the current working directory
-current_dir=$(pwd)
+GITHUB_BASE="https://github.com/"
+REPOS_NAME=$(grep url .git/config | head -n 1 | sed 's|.*github.com[:/]\([^/]*/[^.]*\).*|\1|')
+BRANCH_NAME="$(git branch | grep '\*' | awk '{ print $2 }')"
+MODE="${1:-}"
 
-# Define the base path where your repositories are stored
-base_path="$HOME/work/repos/github.com"
+# '#' を '%23' にURLエンコード
+ENCODED_BRANCH_NAME=$(echo "$BRANCH_NAME" | awk '{gsub(/#/, "%23"); print}')
 
-# Check if the current working directory is under the base_path
-if [[ $current_dir == $base_path* ]]; then
-    # Remove the base_path from the current working directory
-    repo_path=${current_dir#"$base_path/"}
-
-    # Open the GitHub URL in the default browser
-    open "https://github.com/$repo_path"
-else
-    echo "Not in a GitHub repository directory."
+if [[ "${MODE}" == "help" ]] || [[ "${MODE}" == "h" ]] || [[ "${MODE}" == "-h" ]]; then
+    echo "Usage: $0 [pr]"
+    exit
 fi
 
+if [[ "${BRANCH_NAME}" == "master" ]] || [[ "${BRANCH_NAME}" == "main" ]]; then
+    URL="${GITHUB_BASE}${REPOS_NAME}"
+else
+    if [[ "${MODE}" == "pr" ]]; then
+        URL="${GITHUB_BASE}${REPOS_NAME}/compare/${ENCODED_BRANCH_NAME}?expand=1"
+    else
+        MODE="branch"
+        URL="${GITHUB_BASE}${REPOS_NAME}/tree/${ENCODED_BRANCH_NAME}"
+    fi
+fi
+
+echo "Open ${MODE} mode ${URL}."
+open "${URL}"

--- a/bin/open_github
+++ b/bin/open_github
@@ -1,29 +1,19 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -euo pipefail
 
-GITHUB_BASE="https://github.com/"
-REPOS_NAME=$(grep url .git/config | head -n 1 | sed 's|.*github.com[:/]\([^/]*/[^.]*\).*|\1|')
-BRANCH_NAME="$(git branch | grep '*' | awk '{ print $2 }')"
-MODE="$1"
+# Get the current working directory
+current_dir=$(pwd)
 
-# '#' を '%23' にURLエンコード
-#ENCODED_BRANCH_NAME=$(printf "%s" "$BRANCH_NAME" | sed 's|#|%23|g')　# これだと#が%23にならない
-ENCODED_BRANCH_NAME=$(echo "$BRANCH_NAME" | awk '{gsub(/#/, "%23"); print}')
+# Define the base path where your repositories are stored
+base_path="$HOME/work/repos/github.com"
 
-if [ "${MODE}" = "help" ] || [ "${MODE}" = "h" ] || [ "${MODE}" = "-h" ]; then
-    echo "Usage: $0 [pr]"
-    exit
-fi
+# Check if the current working directory is under the base_path
+if [[ "$current_dir" == "$base_path"* ]]; then
+    # Remove the base_path from the current working directory
+    repo_path=${current_dir#"$base_path/"}
 
-if [ "${BRANCH_NAME}" = "master" ] || [ "${BRANCH_NAME}" = "main" ]; then
-    URL="${GITHUB_BASE}${REPOS_NAME}"
+    # Open the GitHub URL in the default browser
+    open "https://github.com/$repo_path"
 else
-    if [ "${MODE}" = "pr" ]; then
-        URL="${GITHUB_BASE}${REPOS_NAME}/compare/${ENCODED_BRANCH_NAME}?expand=1"
-    else
-        MODE="branch"
-        URL="${GITHUB_BASE}${REPOS_NAME}/tree/${ENCODED_BRANCH_NAME}"
-    fi
+    echo "Not in a GitHub repository directory." >&2
 fi
-
-echo "Open ${MODE} mode ${URL}."
-open "${URL}"

--- a/bin/scr
+++ b/bin/scr
@@ -1,12 +1,18 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -euo pipefail
 
 main() {
-  mfa_code=""
+  local mfa_code=""
+  local role_arn
+  local mfa_serial
+  local serial_number_option=""
+  local token_code_option=""
+  local AWS_STS_CREDENTIALS
 
-  role_arn=$(aws configure get $AWS_DEFAULT_PROFILE.role_arn)
+  role_arn=$(aws configure get "${AWS_DEFAULT_PROFILE}.role_arn")
 
-  if [ -z "$role_arn" ]; then
-    echo "Error: role_arn is not defined in the AWS configuration."
+  if [[ -z "$role_arn" ]]; then
+    echo "Error: role_arn is not defined in the AWS configuration." >&2
     return 1
   fi
 
@@ -16,36 +22,37 @@ main() {
         mfa_code="$OPTARG"
         ;;
       *)
-        echo "Usage: $0 [-a mfa_code]"
+        echo "Usage: $0 [-a mfa_code]" >&2
         exit 1
         ;;
     esac
   done
 
-  mfa_serial=$(aws configure get $AWS_DEFAULT_PROFILE.mfa_serial)
+  mfa_serial=$(aws configure get "${AWS_DEFAULT_PROFILE}.mfa_serial" || true)
 
-  if [ -n "$mfa_serial" ]; then
+  if [[ -n "$mfa_serial" ]]; then
     serial_number_option="--serial-number $mfa_serial"
-  else
-    serial_number_option=""
   fi
 
-  if [ -n "$mfa_code" ]; then
+  if [[ -n "$mfa_code" ]]; then
     token_code_option="--token-code $mfa_code"
-  else
-    token_code_option=""
   fi
 
-  AWS_STS_CREDENTIALS=`aws sts assume-role \
+  # shellcheck disable=SC2086
+  AWS_STS_CREDENTIALS=$(aws sts assume-role \
     --profile default \
-    --role-arn $role_arn \
-    --role-session-name $AWS_DEFAULT_PROFILE-session \
+    --role-arn "$role_arn" \
+    --role-session-name "${AWS_DEFAULT_PROFILE}-session" \
     $serial_number_option \
-    $token_code_option`
+    $token_code_option)
 
-  AWS_ACCESS_KEY_ID=`echo "${AWS_STS_CREDENTIALS}" | jq -r '.Credentials.AccessKeyId'`
-  AWS_SECRET_ACCESS_KEY=`echo "${AWS_STS_CREDENTIALS}" | jq -r '.Credentials.SecretAccessKey'`
-  AWS_SESSION_TOKEN=`echo "${AWS_STS_CREDENTIALS}" | jq -r '.Credentials.SessionToken'`
+  AWS_ACCESS_KEY_ID=$(echo "${AWS_STS_CREDENTIALS}" | jq -r '.Credentials.AccessKeyId')
+  AWS_SECRET_ACCESS_KEY=$(echo "${AWS_STS_CREDENTIALS}" | jq -r '.Credentials.SecretAccessKey')
+  AWS_SESSION_TOKEN=$(echo "${AWS_STS_CREDENTIALS}" | jq -r '.Credentials.SessionToken')
+
+  export AWS_ACCESS_KEY_ID
+  export AWS_SECRET_ACCESS_KEY
+  export AWS_SESSION_TOKEN
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Makefileに`lint`/`validate`コマンドを追加
- `.shellcheckrc`を追加してshellcheck設定を定義
- `bin/`配下のスクリプトをshellcheck準拠に修正
- `.bashrc`のSC2068エラー（`$@`のクォート）を修正

## 変更ファイル

### 新規追加
- `.shellcheckrc`: shellcheck設定

### Makefile
- `make lint`: shellcheckでスクリプトを検証
- `make validate`: シンボリックリンク整合性チェック

### bin/スクリプト修正
- `#!/usr/bin/env bash` shebangに統一
- `set -euo pipefail` でエラーハンドリング追加
- `[ ]` → `[[ ]]` に変更
- 変数のクォート追加

### .bashrc
- `tmux_ssh`関数の`$@` → `"$@"` に修正（SC2068 error対応）

## Test plan

- [x] `make lint` 実行確認
- [x] `make validate` 実行確認
- [x] `bin/battery` 動作確認
- [x] `bin/get_ssid` 動作確認
- [x] `bin/ogr` 動作確認
- [x] `bin/open_github` 動作確認