### PR TITLE
chore: improve tmux scroll and copy-paste experience

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -18,6 +18,9 @@ unbind s
 # キーストロークのディレイを減らす
 set -sg escape-time 1
 
+# マウス操作を有効にする（スクロール、ペイン選択、リサイズ）
+set-option -g mouse on
+
 # ウィンドウのインデックスを1から始める
 set -g base-index 1
 
@@ -83,15 +86,16 @@ bind-key Space copy-mode \; display "Copy mode!"
 bind-key -T copy-mode-vi v send-key -X begin-selection
 
 # Prefix+Enter/y でコピー
-bind-key -T copy-mode-vi Enter send-key -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
-bind-key -T copy-mode-vi y     send-key -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+bind-key -T copy-mode-vi Enter send-key -X copy-pipe-and-cancel "pbcopy"
+bind-key -T copy-mode-vi y     send-key -X copy-pipe-and-cancel "pbcopy"
 
 # Prefix+p でペースト
 # クリップボードにも保存されているので Cmd-v でもペースト可能
 bind-key p paste-buffer
 
 # vim <=> tmux 間でクリップボード利用を可能にする
-set-option -g default-command "reattach-to-user-namespace -l $SHELL"
+# macOS Sierra以降は reattach-to-user-namespace 不要
+# set-option -g default-command "reattach-to-user-namespace -l $SHELL"
 
 # Esc キーでコピーの反転を解除（コピーモードは抜けない）
 bind-key -T copy-mode-vi Escape send-key -X clear-selection
@@ -131,9 +135,9 @@ bind-key -T copy-mode-vi / command-prompt -i -p "search down" "send -X search-fo
 # ページスクロール
 bind-key -T copy-mode-vi C-n send-key -X page-up
 bind-key -T copy-mode-vi C-f send-key -X page-down
-# ページ送り
-bind-key -T copy-mode-vi C-u send-key -X scroll-up
-bind-key -T copy-mode-vi C-d send-key -X scroll-down
+# 半ページスクロール（Vimライク）
+bind-key -T copy-mode-vi C-u send-key -X halfpage-up
+bind-key -T copy-mode-vi C-d send-key -X halfpage-down
 
 # ウィンドウとペインの番号を1から開始する（デフォルト0）
 set-option -g base-index 1

--- a/.wezterm.lua
+++ b/.wezterm.lua
@@ -30,6 +30,9 @@ config.use_fancy_tab_bar = false
 config.scrollback_lines = 8192
 config.enable_scroll_bar = true
 
+-- Cmd キーで tmux の mouse reporting をバイパスする
+config.bypass_mouse_reporting_modifiers = 'SUPER'
+
 -- https://zenn.dev/link/comments/7e0e1d3d8619dc
 function random_color_scheme()
   math.randomseed(os.time())
@@ -81,6 +84,15 @@ wezterm.on('random-background-image', function(window, pane)
     window:set_config_overrides(overrides)
   end
 end)
+
+-- Cmd+Click で URL を開く（tmux mouse mode でも動作）
+config.mouse_bindings = {
+  {
+    event = { Up = { streak = 1, button = 'Left' } },
+    mods = 'SUPER',
+    action = act.OpenLinkAtMouseCursor,
+  },
+}
 
 config.keys = {
   { key = 'f', mods = 'CTRL|CMD', action = wezterm.action.ToggleFullScreen },


### PR DESCRIPTION
## 概要

tmuxのスクロール・コピペ操作を改善する。大量出力時の操作性向上が目的。

## 変更内容

### `.tmux.conf`

- **マウス操作の有効化** (`set -g mouse on`) — マウスホイールでスクロール＆自動コピーモード突入、ドラッグ選択が可能に
- **半ページスクロール** — `C-u`/`C-d` を `scroll-up`/`scroll-down`(1行) から `halfpage-up`/`halfpage-down` に変更
- **`reattach-to-user-namespace` 廃止** — macOS Sequoia では不要。コピーパイプラインを `pbcopy` 直接利用に簡素化し、`default-command` をコメントアウト

### `.wezterm.lua`

- **`bypass_mouse_reporting_modifiers = 'SUPER'`** — Cmd キーで tmux の mouse reporting をバイパス
- **Cmd+Click で URL を開く** — `mouse_bindings` に `OpenLinkAtMouseCursor` を追加。tmux mouse mode 有効時でもリンククリックが動作するように

## 既知の制限

- tmux のマウスドラッグ選択はペイン表示範囲を超えて自動スクロールしない（tmux 本体の仕様）。長い範囲のコピーはキーボードのコピーモード（`Prefix Space` → `v` → `C-u`/`C-d` → `y`）を使用する

## 影響範囲

- `.tmux.conf`, `.wezterm.lua`
- `reattach-to-user-namespace` への依存を除去

Refs #12
