### PR TITLE
chore: enable tmux allow-passthrough for OSC notifications

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -34,6 +34,9 @@ bind r source-file ~/.tmux.conf \; display "Reloaded!"
 set-option -g default-terminal "screen-256color" # 基本的にはscreen-256colorかtmux-256colorを設定
 set-option -ga terminal-overrides ",xterm-256color:Tc" # tmuxを起動していない時のbash/zshでの$TERMの値を指定
 
+# OSC passthrough を許可（DCS で包んだ OSC を WezTerm まで通す。ai-development-hub の通知フック notify.sh が pane_tty へ書く OSC 777 用。tmux 3.3+）
+set-option -g allow-passthrough on
+
 # エスケープシーケンスの問題を軽減するための設定
 set-option -g set-titles on
 set-option -g set-titles-string '#T'


### PR DESCRIPTION
## 目的

ai-development-hub の通知フック（`notify.sh`）が、エージェントの完了/入力待ちを **WezTerm の OSC 777 通知**として出す。tmux 内ではフックが controlling TTY を持たないため、`#{pane_tty}` へ DCS passthrough で包んだ OSC を書き込む方式を採る。これには tmux 側で `allow-passthrough` を有効化する必要がある。

## 変更

- `.tmux.conf` に `set-option -g allow-passthrough on` を追加（terminal 設定の直後）

## 背景

- macOS では CLI/フック文脈から `osascript`/`terminal-notifier` を叩いても通知が表示されないことがある（GUI 権限を持つアプリが出す必要がある）。WezTerm は GUI アプリなので OSC を受けて通知を出せる
- tmux はデフォルトで OSC を遮断するため、`allow-passthrough on`（tmux 3.3+）＋ DCS 包みが必要

## 適用

`make deploy`（symlink）後、tmux を再起動 or `tmux source-file ~/.tmux.conf` + `tmux set -g allow-passthrough on` で反映。

Ref: stlwolf/ai-development-hub#119
