### PR TITLE
chore: show repo name and AI agent prefix in tmux window list

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -81,12 +81,13 @@ set-option -g status-justify centre
 
 # センター表示のウィンドウ名(#W)を「カレントディレクトリ名」にする。
 # AIエージェント稼働中のペインは判定して接頭辞を付ける:
-#   Claude Code … プロセス名がバージョン文字列(例 2.1.160)なので *.*.* で一致 → CC:
+#   Claude Code … プロセス名が数値バージョン文字列(例 2.1.160)なので [0-9]*.[0-9]*.[0-9]* で一致 → CC:
 #   Codex       … プロセス名が codex-aarch64-a 等なので codex* で一致 → CX:
 #   素のシェル・一般コマンド … 接頭辞なしでディレクトリ名のみ
 # 判定はプロセス名ベースのヒューリスティック。エージェント側がプロセス名を変えると外れるが、その時はこの1行を直す。
+# (数値semver形のパターンにすることで go1.21.0 等のドット2個以上を含むコマンドへの誤一致を防ぐ)
 # 手動 rename-window したウィンドウは automatic-rename が無効化され、従来どおりその名前が優先される。
-set-option -g automatic-rename-format '#{?#{m:*.*.*,#{pane_current_command}},CC:,#{?#{m:codex*,#{pane_current_command}},CX:,}}#{b:pane_current_path}'
+set-window-option -g automatic-rename-format '#{?#{m:[0-9]*.[0-9]*.[0-9]*,#{pane_current_command}},CC:,#{?#{m:codex*,#{pane_current_command}},CX:,}}#{b:pane_current_path}'
 
 # Vi キーバインド
 set-window-option -g mode-keys vi

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -79,6 +79,15 @@ set-option -g status-interval 1
 # センタライズ（主にウィンドウ番号など）
 set-option -g status-justify centre
 
+# センター表示のウィンドウ名(#W)を「カレントディレクトリ名」にする。
+# AIエージェント稼働中のペインは判定して接頭辞を付ける:
+#   Claude Code … プロセス名がバージョン文字列(例 2.1.160)なので *.*.* で一致 → CC:
+#   Codex       … プロセス名が codex-aarch64-a 等なので codex* で一致 → CX:
+#   素のシェル・一般コマンド … 接頭辞なしでディレクトリ名のみ
+# 判定はプロセス名ベースのヒューリスティック。エージェント側がプロセス名を変えると外れるが、その時はこの1行を直す。
+# 手動 rename-window したウィンドウは automatic-rename が無効化され、従来どおりその名前が優先される。
+set-option -g automatic-rename-format '#{?#{m:*.*.*,#{pane_current_command}},CC:,#{?#{m:codex*,#{pane_current_command}},CX:,}}#{b:pane_current_path}'
+
 # Vi キーバインド
 set-window-option -g mode-keys vi
 


### PR DESCRIPTION
## 概要

tmux センターステータスバーのウィンドウ名（`#W`）を、可読性のある情報にする。

複数ウィンドウ/ペインが増えた結果、センター表示が `pane_current_command` 由来（素のシェルは `bash`、Claude Code はバージョン文字列 `2.1.x`、Codex は `codex-aarch64-a`）になり、どのウィンドウが何かを読み取りづらくなっていた。`automatic-rename-format` を上書きし、ウィンドウ名を「カレントディレクトリ名（リポジトリ直下なら repo 名）」にする。AIエージェント稼働中のペインはプロセス名で判定して接頭辞を付ける。

## 変更内容

- `.tmux.conf` の `status-justify centre` 付近に `automatic-rename-format` を1行追加（既存の `window-status-format`・色設定・キーバインドは変更なし）

```tmux
set-option -g automatic-rename-format '#{?#{m:*.*.*,#{pane_current_command}},CC:,#{?#{m:codex*,#{pane_current_command}},CX:,}}#{b:pane_current_path}'
```

判定ロジック:

- Claude Code … プロセス名がバージョン文字列（例 `2.1.160`）なので `*.*.*` で一致 → `CC:`
- Codex … プロセス名が `codex-aarch64-a` 等なので `codex*` で一致 → `CX:`
- 素のシェル・一般コマンド … 接頭辞なしでディレクトリ名（`#{b:pane_current_path}`）のみ
- 手動 `rename-window` したウィンドウは `automatic-rename` が無効化され、従来どおりその名前が優先

## 表示例（全分岐を実機確認済み）

| ペイン種別 | `pane_current_command` | 表示結果 |
|---|---|---|
| Claude Code | `2.1.160`（バージョン文字列） | `CC:dotfiles` |
| Codex | `codex-aarch64-a` | `CX:dotfiles` |
| 素のシェル | `bash` | `ai-development-hub`（接頭辞なし） |

## 検証

- [x] `make lint` … exit 0（警告は既存 shell ファイルのみ、`.tmux.conf` は lint 対象外）
- [x] `tmux source-file ~/.tmux.conf` でリロード → アクティブウィンドウが `CC:dotfiles` に更新
- [x] 使い捨てデタッチセッションで Codex を起動し `CX:dotfiles` を確認（起動/検査/破棄）
- [x] 使い捨てデタッチセッションで素の bash を起動しディレクトリ名命名を確認
- [x] `make validate` … exit 0、`.tmux.conf` は `OK`

## リスク / 留意点

- 判定はプロセス名ベースのヒューリスティック。将来 Claude/Codex がプロセス名を変えると接頭辞が外れる（ディレクトリ名表示にフォールバックするだけで実害は小）。その場合はこの1行を修正する。
- 既存の idle ウィンドウは旧名のまま残り、次にフォーカス／出力が出た時点で新フォーマットに切り替わる（tmux の `automatic-rename` 仕様）。
- ホームでエージェントを起動した場合は `CC:eddy` のように repo 名にならない（repo 外なので想定どおり）。

## テスト方法

```bash
tmux source-file ~/.tmux.conf
# 各ウィンドウを一度フォーカスすると新フォーマットが反映される
tmux list-windows -a -F '#{window_index}:#{window_name}'
```
