### PR TITLE
feat(wezterm): wez notify の toast 表示を開通する

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -35,13 +35,15 @@ if is_ai_ide; then
     export MANPATH="/opt/homebrew/share/man${MANPATH+:$MANPATH}:"
     export INFOPATH="/opt/homebrew/share/info:${INFOPATH:-}"
 
-    # WezTerm socket auto-detect for AI IDE
+    # WezTerm socket auto-detect for AI IDE (mtime-newest; -nt で ls/SC2012 を回避)
     if [[ -z "${WEZTERM_UNIX_SOCKET:-}" ]]; then
-        _wez_sock=$(ls -t ~/.local/share/wezterm/gui-sock-* 2>/dev/null | head -1)
-        if [[ -n "$_wez_sock" ]]; then
-            export WEZTERM_UNIX_SOCKET="$_wez_sock"
-        fi
-        unset _wez_sock
+        _wez_newest=""
+        for _wez_sock in "$HOME"/.local/share/wezterm/gui-sock-*; do
+            [[ -e "$_wez_sock" ]] || continue
+            [[ -z "$_wez_newest" || "$_wez_sock" -nt "$_wez_newest" ]] && _wez_newest="$_wez_sock"
+        done
+        [[ -n "$_wez_newest" ]] && export WEZTERM_UNIX_SOCKET="$_wez_newest"
+        unset _wez_sock _wez_newest
     fi
 else
     # 通常のターミナルでは brew shellenv を実行

--- a/.bashrc
+++ b/.bashrc
@@ -34,6 +34,15 @@ if is_ai_ide; then
     export PATH="/opt/homebrew/bin:/opt/homebrew/sbin${PATH+:$PATH}"
     export MANPATH="/opt/homebrew/share/man${MANPATH+:$MANPATH}:"
     export INFOPATH="/opt/homebrew/share/info:${INFOPATH:-}"
+
+    # WezTerm socket auto-detect for AI IDE
+    if [[ -z "${WEZTERM_UNIX_SOCKET:-}" ]]; then
+        _wez_sock=$(ls -t ~/.local/share/wezterm/gui-sock-* 2>/dev/null | head -1)
+        if [[ -n "$_wez_sock" ]]; then
+            export WEZTERM_UNIX_SOCKET="$_wez_sock"
+        fi
+        unset _wez_sock
+    fi
 else
     # 通常のターミナルでは brew shellenv を実行
     eval "$(/opt/homebrew/bin/brew shellenv)"

--- a/.bashrc
+++ b/.bashrc
@@ -39,7 +39,7 @@ if is_ai_ide; then
     if [[ -z "${WEZTERM_UNIX_SOCKET:-}" ]]; then
         _wez_newest=""
         for _wez_sock in "$HOME"/.local/share/wezterm/gui-sock-*; do
-            [[ -e "$_wez_sock" ]] || continue
+            [[ -S "$_wez_sock" ]] || continue
             [[ -z "$_wez_newest" || "$_wez_sock" -nt "$_wez_newest" ]] && _wez_newest="$_wez_sock"
         done
         [[ -n "$_wez_newest" ]] && export WEZTERM_UNIX_SOCKET="$_wez_newest"

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ Temporary Items
 .apdisk
 
 .idea/*
+
+# AI tooling / scratch
+tmp/
+.antigravitycli/

--- a/.wezterm.lua
+++ b/.wezterm.lua
@@ -135,4 +135,22 @@ config.window_background_image_hsb = {
   saturation = 1.0,
 }
 
+-- AI Mode: shell から user-var (OSC 1337 SetUserVar) を受けて toast 通知を出す
+wezterm.on('user-var-changed', function(window, pane, name, value)
+  if name == 'ai_notify' then
+    local decoded = value
+    local title, body, timeout_str = decoded:match('^([^|]*)|([^|]*)|([^|]*)$')
+    title = (title and title ~= '') and title or 'AI Mode'
+    body = body or ''
+    local timeout = tonumber(timeout_str) or 4000
+
+    window:toast_notification('WezTerm AI', title .. ': ' .. body, nil, timeout)
+    wezterm.log_info('ai_notify: ' .. title .. ' - ' .. body)
+  end
+
+  if name == 'ai_status' then
+    wezterm.log_info('ai_status: ' .. value)
+  end
+end)
+
 return config

--- a/.wezterm.lua
+++ b/.wezterm.lua
@@ -148,11 +148,10 @@ wezterm.on('user-var-changed', function(window, pane, name, value)
     body = body or ''
     local timeout = tonumber(timeout_str) or 4000
 
-    window:toast_notification('WezTerm AI', title .. ': ' .. body, nil, timeout)
+    local message = (body ~= '') and (title .. ': ' .. body) or title
+    window:toast_notification('WezTerm AI', message, nil, timeout)
     wezterm.log_info('ai_notify: ' .. title .. ' - ' .. body)
-  end
-
-  if name == 'ai_status' then
+  elseif name == 'ai_status' then
     wezterm.log_info('ai_status: ' .. value)
   end
 end)

--- a/.wezterm.lua
+++ b/.wezterm.lua
@@ -140,6 +140,10 @@ wezterm.on('user-var-changed', function(window, pane, name, value)
   if name == 'ai_notify' then
     local decoded = value
     local title, body, timeout_str = decoded:match('^([^|]*)|([^|]*)|([^|]*)$')
+    if not title then
+      -- パイプ区切りでない値（将来のフォーマット変更や手動送信）は生値を title に
+      title, body, timeout_str = decoded, '', nil
+    end
     title = (title and title ~= '') and title or 'AI Mode'
     body = body or ''
     local timeout = tonumber(timeout_str) or 4000


### PR DESCRIPTION
## 概要

WezTerm の `wez notify` で **toast 通知が表示されない**問題（Phase 1 から持ち越し、ADR-006）を解消する。`.wezterm.lua` に user-var ハンドラを統合し、`.bashrc` に socket 自動 export を追加する。

Refs stlwolf/ai-development-hub#86

## 背景

- `wez notify` は OSC 1337 `SetUserVar` でペイロードを送るが、toast 表示には `.wezterm.lua` 側の `user-var-changed` → `toast_notification` ハンドラが必要（ADR-006 で Phase 2 に先送りされていた）。
- AI IDE（Cursor 等）統合ターミナルには `WEZTERM_UNIX_SOCKET` が伝搬せず、stale socket 問題（課題A）が発生していた。

## 変更内容

### `.wezterm.lua`（feat）
- `return config` 直前に `wezterm.on('user-var-changed', ...)` をインライン追加（既存イベントハンドラと同じ直書きスタイル）。
- パーサは `string.match('^([^|]*)|([^|]*)|([^|]*)$')` で `title|body|timeout` を固定3フィールド抽出。PoC の `gmatch('[^|]+')` は**空 body セグメントで timeout が body にずれる**問題（ADR-007 DJ-3）があったため修正。
- `ai_notify` → `window:toast_notification(...)` + `wezterm.log_info(...)`、`ai_status` → `log_info`。

### `.bashrc`（feat）
- `is_ai_ide()` の Homebrew ブロック内で、`WEZTERM_UNIX_SOCKET` 未設定時のみ `~/.local/share/wezterm/gui-sock-*` の mtime 最新を自動 export。socket が無ければ no-op、既設定なら非上書き。

### `.gitignore`（chore）
- `tmp/` と `.antigravitycli/` を ignore 化。

## 検証

- `make lint`: 新規 finding は `.bashrc` の `SC2012`(info) のみ（socket 名は常に英数字 `gui-sock-<PID>` のため実害なし）。
- `make validate`: `OK: .bashrc` / `OK: .wezterm.lua`。
- socket export ロジック（シェル）: 未設定→最新 socket を export / 既設定→非上書き / socket 無し→ no-op を確認。
- **ライブ toast**: WezTerm 自動リロード後、`wez notify "test" "hello"` と `wez notify "title only"`（空 body）を実行。GUI ログで `ai_notify: test - hello` / `ai_notify: title only - `（body が空のままずれない）を確認 = DJ-3 修正の実証。

## 影響範囲

- 個人 dotfiles のみ。`.tmux.conf` の `allow-passthrough`（既存コミット #16 で対応済）・CLI 側 `lib/notify.sh`（ペイロード形式）は変更なし。
